### PR TITLE
ignore dirtree listing in index

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,5 +1,7 @@
 ---
 title: EyebrowHairs
+dirtree:
+  display: False
 ---
 
 ::: {.ui .center .aligned .header}


### PR DESCRIPTION
If you want to ignore the `dirtree` listing at the very end of https://www.eyebrowhairs.com/ then this will do.